### PR TITLE
fix: standardize resource_tags variable, update descriptions and add access tag validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ You need the following permissions to run this module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access management tags to be attached to the bare metal server for categorization and policy enforcement. | `list(string)` | `[]` | no |
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | Add access management tags to the IBM Cloud Bare Metal Servers for VPC instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console). | `list(string)` | `[]` | no |
 | <a name="input_allowed_vlan_ids"></a> [allowed\_vlan\_ids](#input\_allowed\_vlan\_ids) | A list of VLAN IDs that are permitted for the bare metal server, ensuring network isolation and control. Example: [100, 102] | `list(number)` | `[]` | no |
 | <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The allocated bandwidth (in Mbps) for the bare metal server to manage network traffic. If unset, default values apply. | `number` | `null` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Setting to true will be create a new security group | `bool` | `false` | no |
@@ -202,6 +202,7 @@ You need the following permissions to run this module.
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The base name for the bare metal server. If multiple instances are created, an index will be appended for uniqueness. | `string` | n/a | yes |
 | <a name="input_profile"></a> [profile](#input\_profile) | The hardware profile defining the CPU, memory, and storage configuration of the bare metal server. | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | ID of the resource group where you want to create the service. | `string` | `null` | no |
+| <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Add user resource tags to the IBM Cloud Bare Metal Servers for VPC instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types). | `list(string)` | `[]` | no |
 | <a name="input_secondary_allowed_vlan_ids"></a> [secondary\_allowed\_vlan\_ids](#input\_secondary\_allowed\_vlan\_ids) | List of allowed VLAN IDs for secondary VNIs | `list(number)` | `[]` | no |
 | <a name="input_secondary_security_group_ids"></a> [secondary\_security\_group\_ids](#input\_secondary\_security\_group\_ids) | List of security group IDs for secondary VNIs | `list(string)` | `[]` | no |
 | <a name="input_secondary_subnet_ids"></a> [secondary\_subnet\_ids](#input\_secondary\_subnet\_ids) | List of secondary subnet IDs (if empty, will use primary subnets) | `list(string)` | `[]` | no |
@@ -211,7 +212,6 @@ You need the following permissions to run this module.
 | <a name="input_server_count"></a> [server\_count](#input\_server\_count) | Specifies the number of bare metal server instances to provision. If greater than one, multiple instances will be created and distributed across the available subnets in a round-robin manner. For example, if the server count is 3 and there are 2 subnets, Server 1 and Server 3 will be deployed on Subnet 1, while Server 2 will be deployed on Subnet 2. | `number` | `1` | no |
 | <a name="input_ssh_key_ids"></a> [ssh\_key\_ids](#input\_ssh\_key\_ids) | A list of SSH key IDs that will be used for secure access to the bare metal server. | `list(string)` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs where the bare metal server will be deployed, ensuring proper network segmentation. | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | List of tags to apply to resources created by this module. | `list(string)` | `[]` | no |
 | <a name="input_tpm_mode"></a> [tpm\_mode](#input\_tpm\_mode) | Trusted platform module (TPM) configuration for the bare metal server. For more details see [Secure Boot and TPM documentation](https://cloud.ibm.com/docs/vpc?topic=vpc-secure-boot-tpm) | `string` | `"disabled"` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data to initialize BMS deployment | `string` | `null` | no |
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -93,6 +93,8 @@ module "slz_baremetal" {
   server_count          = 2
   prefix                = var.prefix
   profile               = var.profile
+  resource_tags         = var.resource_tags
+  access_tags           = var.access_tags
   image_id              = data.ibm_is_image.slz_vsi_image.id
   subnet_ids            = [[for subnet in module.slz_vpc.subnet_zone_list : subnet.id if subnet.zone == "${var.region}-${var.zone}"][0]]
   ssh_key_ids           = [local.ssh_key_id]

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -155,6 +155,5 @@ module "slz_baremetal" {
   secondary_vni_enabled = true
   secondary_subnet_ids  = [[for subnet in module.slz_vpc.subnet_zone_list : subnet.id if subnet.zone == "${var.region}-${var.zone}"][1]]
 
-  access_tags       = null
   resource_group_id = module.resource_group.resource_group_id
 }

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -36,6 +36,12 @@ variable "resource_tags" {
   default     = null
 }
 
+variable "access_tags" {
+  description = "Optional list of access management tags to attach to the IBM Cloud Bare Metal Servers for VPC instance."
+  type        = list(string)
+  default     = []
+}
+
 variable "vpc_name" {
   type        = string
   description = "The name of the IBM Cloud Virtual Private Cloud (VPC) where the servers will be deployed."

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -74,6 +74,5 @@ module "slz_baremetal" {
   security_group_ids    = []
   user_data             = null
   allowed_vlan_ids      = ["100", "102"]
-  access_tags           = null
   resource_group_id     = module.resource_group.resource_group_id
 }

--- a/examples/multi-zone-deployment/main.tf
+++ b/examples/multi-zone-deployment/main.tf
@@ -73,6 +73,5 @@ module "slz_baremetal" {
   create_security_group = false
   security_group_ids    = []
   user_data             = null
-  access_tags           = null
   resource_group_id     = module.resource_group.resource_group_id
 }

--- a/modules/baremetal/README.md
+++ b/modules/baremetal/README.md
@@ -75,7 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access management tags to be attached to the bare metal server for categorization and policy enforcement. | `list(string)` | `[]` | no |
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | Add access management tags to the IBM Cloud Bare Metal Servers for VPC instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console). | `list(string)` | `[]` | no |
 | <a name="input_allowed_vlan_ids"></a> [allowed\_vlan\_ids](#input\_allowed\_vlan\_ids) | A list of VLAN IDs that are permitted for the bare metal server, ensuring network isolation and control. Example: [100, 102] | `list(number)` | `[]` | no |
 | <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The allocated bandwidth (in Mbps) for the bare metal server to manage network traffic. If unset, default values apply. | `number` | `null` | no |
 | <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | Timeout for creating the bare metal server | `string` | `"60m"` | no |

--- a/modules/baremetal/README.md
+++ b/modules/baremetal/README.md
@@ -69,7 +69,7 @@ No modules.
 | [ibm_is_subnet_reserved_ip.bms_secondary_reserved_ip](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_subnet_reserved_ip) | resource |
 | [ibm_is_virtual_network_interface.bms](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_network_interface) | resource |
 | [ibm_is_virtual_network_interface.bms_secondary](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_network_interface) | resource |
-| [ibm_iam_access_tag.access_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/iam_access_tag) | data source |
+| [ibm_iam_access_tag.access_tags](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/iam_access_tag) | data source |
 | [ibm_is_subnet.subnet](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/is_subnet) | data source |
 
 ### Inputs

--- a/modules/baremetal/README.md
+++ b/modules/baremetal/README.md
@@ -69,6 +69,7 @@ No modules.
 | [ibm_is_subnet_reserved_ip.bms_secondary_reserved_ip](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_subnet_reserved_ip) | resource |
 | [ibm_is_virtual_network_interface.bms](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_network_interface) | resource |
 | [ibm_is_virtual_network_interface.bms_secondary](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_network_interface) | resource |
+| [ibm_iam_access_tag.access_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/iam_access_tag) | data source |
 | [ibm_is_subnet.subnet](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/is_subnet) | data source |
 
 ### Inputs

--- a/modules/baremetal/main.tf
+++ b/modules/baremetal/main.tf
@@ -2,6 +2,12 @@ data "ibm_is_subnet" "subnet" {
   identifier = var.subnet_id
 }
 
+# Check whether access tags are valid and exist in the account
+data "ibm_iam_access_tag" "access_tag" {
+  for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
+  name     = each.value
+}
+
 # Primary reserved IP
 resource "ibm_is_subnet_reserved_ip" "bms_primary_reserved_ip" {
   count       = var.manage_reserved_ips ? 1 : 0
@@ -50,6 +56,7 @@ resource "ibm_is_virtual_network_interface" "bms_secondary" {
 }
 
 resource "ibm_is_bare_metal_server" "bms" {
+  depends_on         = [data.ibm_iam_access_tag.access_tag] # Force dependency on data source validation to ensure access_tags exist and are valid before use.
   profile            = var.profile
   name               = var.name
   image              = var.image_id

--- a/modules/baremetal/main.tf
+++ b/modules/baremetal/main.tf
@@ -3,7 +3,7 @@ data "ibm_is_subnet" "subnet" {
 }
 
 # Check whether access tags are valid and exist in the account
-data "ibm_iam_access_tag" "access_tag" {
+data "ibm_iam_access_tag" "access_tags" {
   for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
   name     = each.value
 }
@@ -56,7 +56,7 @@ resource "ibm_is_virtual_network_interface" "bms_secondary" {
 }
 
 resource "ibm_is_bare_metal_server" "bms" {
-  depends_on         = [data.ibm_iam_access_tag.access_tag] # Force dependency on data source validation to ensure access_tags exist and are valid before use.
+  depends_on         = [data.ibm_iam_access_tag.access_tags] # Force dependency on data source validation to ensure access_tags exist and are valid before use.
   profile            = var.profile
   name               = var.name
   image              = var.image_id

--- a/modules/baremetal/variables.tf
+++ b/modules/baremetal/variables.tf
@@ -43,7 +43,7 @@ variable "allowed_vlan_ids" {
 }
 
 variable "access_tags" {
-  description = "A list of access management tags to be attached to the bare metal server for categorization and policy enforcement."
+  description = "Add access management tags to the IBM Cloud Bare Metal Servers for VPC instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   type        = list(string)
   default     = []
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -38,7 +38,7 @@ module "sg_group" {
   security_group_name          = "${var.prefix}-sg"
   security_group_rules         = var.security_group_rules
   vpc_id                       = values(data.ibm_is_subnet.subnet)[0].vpc
-  tags                         = var.tags
+  tags                         = var.resource_tags
 }
 
 ##############################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "resource_tags" {
   type        = list(string)
   default     = []
   validation {
-    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
     error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
   }
   nullable = false

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "allowed_vlan_ids" {
 }
 
 variable "access_tags" {
-  description = "A list of access management tags to be attached to the bare metal server for categorization and policy enforcement."
+  description = "Add access management tags to the IBM Cloud Bare Metal Servers for VPC instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   type        = list(string)
   default     = []
 }
@@ -59,11 +59,15 @@ variable "subnet_ids" {
 
 }
 
-variable "tags" {
-  description = "List of tags to apply to resources created by this module."
+variable "resource_tags" {
+  description = "Add user resource tags to the IBM Cloud Bare Metal Servers for VPC instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   type        = list(string)
   default     = []
-  nullable    = false
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
+  nullable = false
 }
 
 variable "create_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,13 @@ variable "access_tags" {
   description = "Add access management tags to the IBM Cloud Bare Metal Servers for VPC instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   type        = list(string)
   default     = []
+
+  validation {
+    condition = alltrue([
+      for tag in var.access_tags : can(regex("[\\w\\-_\\.]+:[\\w\\-_\\.]+", tag)) && length(tag) <= 128
+    ])
+    error_message = "Tags must match the regular expression `\"[\\w\\-_\\.]+:[\\w\\-_\\.]+\"`. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#limits)."
+  }
 }
 
 variable "ssh_key_ids" {


### PR DESCRIPTION
This PR updates:

- tags -> resource_tags
- resource_tags variable description and validation
- access_tags variable description
- Adds data block to ensure existing access_tags are being attached to the instance

### Release required?

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)
